### PR TITLE
R4 37

### DIFF
--- a/asyn.Makefile
+++ b/asyn.Makefile
@@ -213,25 +213,23 @@ SOURCES += $(ASYNPORTCLIENT)/asynPortClient.cpp
 # This block is here to inflate devEpics.dbd with the following .dbd files.
 ############
 DBDCAT += $(COMMON_DIR)/devEpics.dbd 
-# This is a bit of a hack, as the rule that creates the dbd file is in RULES.Db from EPICS_BASE, so we can not touch it.
-DBDCAT_PREFIX = 
 
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynOctet.dbd
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt32.dbd
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt8Array.dbd
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt16Array.dbd
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt32Array.dbd
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt32TimeSeries.dbd
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynUInt32Digital.dbd
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat64.dbd
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat32Array.dbd
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat64Array.dbd
-devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat64TimeSeries.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynOctet.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynInt32.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynInt8Array.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynInt16Array.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynInt32Array.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynInt32TimeSeries.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynUInt32Digital.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynFloat64.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynFloat32Array.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynFloat64Array.dbd
+devEpics_DBD +=   $(DEVEPICS)/devAsynFloat64TimeSeries.dbd
 
 # ESS Supports only Base 7+ in E3
-devEpics_DBD += $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt64.dbd
-devEpics_DBD += $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt64Array.dbd
-devEpics_DBD += $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt64TimeSeries.dbd
+devEpics_DBD += $(DEVEPICS)/devAsynInt64.dbd
+devEpics_DBD += $(DEVEPICS)/devAsynInt64Array.dbd
+devEpics_DBD += $(DEVEPICS)/devAsynInt64TimeSeries.dbd
 
 DBDS += $(devEpics_DBD)
 
@@ -337,9 +335,8 @@ SOURCES += $(DEVGPIB)/boSRQonOff.c
 DBDS    += $(DEVGPIB)/devGpib.dbd
 
 
+# Override the default DBDCAT_COMMAND
 $(COMMON_DIR)/devEpics.dbd: DBDCAT_COMMAND = $(PERL) $(TOOLS)/makeIncludeDbd.pl $(devEpics_DBD) $(notdir $@)
-
-$(COMMON_DIR)/%.dbd: DBDCAT_PREFIX=../
 
 
 SCRIPTS += $(wildcard ../iocsh/*.iocsh)

--- a/asyn.Makefile
+++ b/asyn.Makefile
@@ -1,6 +1,7 @@
 #
-#  Copyright (c) 2017 - 2019  Jeong Han Lee
-#  Copyright (c) 2017 - 2019  European Spallation Source ERIC
+#  Copyright (c) 2020 - Present  Simon Rose
+#  Copyright (c) 2017 - 2019     Jeong Han Lee
+#  Copyright (c) 2017 - 2019     European Spallation Source ERIC
 #
 #  The program is free software: you can redistribute
 #  it and/or modify it under the terms of the GNU General Public License
@@ -15,10 +16,15 @@
 #  You should have received a copy of the GNU General Public License along with
 #  this program. If not, see https://www.gnu.org/licenses/gpl-2.0.txt
 #
-# Author  : Jeong Han Lee
-# email   : jeonghan.lee@gmail.com
-# Date    : Wednesday, September  4 00:01:38 CEST 2019
-# version : 0.1.6
+# Author   : Jeong Han Lee
+# email    : jeonghan.lee@gmail.com
+# Date     : Wednesday, September  4 00:01:38 CEST 2019
+# version  : 0.1.6
+#
+# Author 2 : Simon Rose
+# email    : simon.rose@ess.eu
+# Date     : Monday, March 2 2020
+# version  : 4.37.0
 
 
 LEGACY_RSET = YES

--- a/asyn.Makefile
+++ b/asyn.Makefile
@@ -209,47 +209,40 @@ HEADERS += $(ASYNPORTCLIENT)/asynPortClient.h
 SOURCES += $(ASYNPORTCLIENT)/asynPortClient.cpp
 
 
-###################################################
-# devEpics.dbd will be generated at build time 
-###################################################
-DBDS      += $(COMMON_DIR)/devEpics.dbd
+############
+# This block is here to inflate devEpics.dbd with the following .dbd files.
+############
+DBDCAT += $(COMMON_DIR)/devEpics.dbd 
+# This is a bit of a hack, as the rule that creates the dbd file is in RULES.Db from EPICS_BASE, so we can not touch it.
+DBDCAT_PREFIX = 
 
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynOctet.dbd
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynInt32.dbd
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynInt8Array.dbd
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynInt16Array.dbd
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynInt32Array.dbd
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynInt32TimeSeries.dbd
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynUInt32Digital.dbd
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynFloat64.dbd
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynFloat32Array.dbd
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynFloat64Array.dbd
-devEpics.dbd_SNIPPETS +=   $(where_am_I)$(DEVEPICS)/devAsynFloat64TimeSeries.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynOctet.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt32.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt8Array.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt16Array.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt32Array.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt32TimeSeries.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynUInt32Digital.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat64.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat32Array.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat64Array.dbd
+devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat64TimeSeries.dbd
 
 # only for BASE 7 or 3.16 with modification
-devEpics.dbd_SNIPPETS += $(where_am_I)$(DEVEPICS)/devAsynInt64.dbd
-devEpics.dbd_SNIPPETS += $(where_am_I)$(DEVEPICS)/devAsynInt64Array.dbd
-devEpics.dbd_SNIPPETS += $(where_am_I)$(DEVEPICS)/devAsynInt64TimeSeries.dbd
+devEpics_DBD += $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt64.dbd
+devEpics_DBD += $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt64Array.dbd
+devEpics_DBD += $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt64TimeSeries.dbd
 
-################################################################
-# These need to be included otherwise asyn.dbd won't have them
-################################################################
-DBDS      += $(DEVEPICS)/devAsynOctet.dbd
-DBDS      += $(DEVEPICS)/devAsynInt32.dbd
-DBDS      += $(DEVEPICS)/devAsynInt8Array.dbd
-DBDS      += $(DEVEPICS)/devAsynInt16Array.dbd
-DBDS      += $(DEVEPICS)/devAsynInt32Array.dbd
-DBDS      += $(DEVEPICS)/devAsynInt32TimeSeries.dbd
-DBDS      += $(DEVEPICS)/devAsynUInt32Digital.dbd
-DBDS      += $(DEVEPICS)/devAsynFloat64.dbd
-DBDS      += $(DEVEPICS)/devAsynFloat32Array.dbd
-DBDS      += $(DEVEPICS)/devAsynFloat64Array.dbd
-DBDS      += $(DEVEPICS)/devAsynFloat64TimeSeries.dbd
+DBDS += $(devEpics_DBD)
 
-DBDS 	+= $(DEVEPICS)/devAsynInt64.dbd
-DBDS 	+= $(DEVEPICS)/devAsynInt64Array.dbd
-DBDS 	+= $(DEVEPICS)/devAsynInt64TimeSeries.dbd
-#####
+DBD_SRCS += $(DBDCAT)
+
+# We have to include a special file /after/ we have updated DBDCAT.
+include $(E3_REQUIRE_CONFIG)/RULES_DBDCAT
+################
+# Up until here.
+################
+
 
 
 TEMPLATES += $(DEVEPICS)/asynInt32TimeSeries.db
@@ -344,16 +337,10 @@ SOURCES += $(DEVGPIB)/boSRQonOff.c
 DBDS    += $(DEVGPIB)/devGpib.dbd
 
 
-# 
-# This will generate "devEpics.dbd" with the include statements for other DBDs,
-# the original asyn Makefile has different rules depending on "DBDCAT_COMMAND".
-# Needs to be clarified...
-#
-$(COMMON_DIR)/devEpics.dbd: $(devEpics.dbd_SNIPPETS)
-	$(ECHO) "Creating dbd file $(notdir $@)"
-	@$(RM) $(notdir $@)
-	$(PERL) $(TOOLS)/makeIncludeDbd.pl $(devEpics.dbd_SNIPPETS) $(notdir $@)
-	@$(MV) $(notdir $@) $@
+$(COMMON_DIR)/devEpics.dbd: DBDCAT_COMMAND = $(PERL) $(TOOLS)/makeIncludeDbd.pl $(devEpics_DBD) $(notdir $@)
+
+$(COMMON_DIR)/%.dbd: DBDCAT_PREFIX=../
+
 
 SCRIPTS += $(wildcard ../iocsh/*.iocsh)
 

--- a/asyn.Makefile
+++ b/asyn.Makefile
@@ -228,7 +228,7 @@ devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat32Array.dbd
 devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat64Array.dbd
 devEpics_DBD +=   $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynFloat64TimeSeries.dbd
 
-# only for BASE 7 or 3.16 with modification
+# ESS Supports only Base 7+ in E3
 devEpics_DBD += $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt64.dbd
 devEpics_DBD += $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt64Array.dbd
 devEpics_DBD += $(DBDCAT_PREFIX)$(DEVEPICS)/devAsynInt64TimeSeries.dbd
@@ -263,7 +263,7 @@ SOURCES   += $(DEVEPICS)/devAsynFloat32Array.c
 SOURCES   += $(DEVEPICS)/devAsynFloat64Array.c
 SOURCES   += $(DEVEPICS)/devAsynFloat64TimeSeries.c
 
-# only for BASE 7 or 3.16 with modification
+# ESS Supports only Base 7+ in E3
 SOURCES   += $(DEVEPICS)/devAsynInt64.c
 SOURCES   += $(DEVEPICS)/devAsynInt64Array.c
 SOURCES   += $(DEVEPICS)/devAsynInt64TimeSeries.c

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -2,7 +2,7 @@
 EPICS_BASE:=/epics/base-7.0.3.1
 
 E3_REQUIRE_NAME:=require
-E3_REQUIRE_VERSION:=simonrose
+E3_REQUIRE_VERSION:=3.2.0
 
 # The definitions shown below can also be placed in an untracked RELEASE.local
 #-include $(TOP)/../../RELEASE.local

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -5,7 +5,7 @@ E3_REQUIRE_NAME:=require
 E3_REQUIRE_VERSION:=3.2.0
 
 # The definitions shown below can also be placed in an untracked RELEASE.local
-#-include $(TOP)/../../RELEASE.local
-#-include $(TOP)/../RELEASE.local
+-include $(TOP)/../../RELEASE.local
+-include $(TOP)/../RELEASE.local
 -include $(TOP)/configure/RELEASE.local
 

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -2,10 +2,10 @@
 EPICS_BASE:=/epics/base-7.0.3.1
 
 E3_REQUIRE_NAME:=require
-E3_REQUIRE_VERSION:=3.1.2
+E3_REQUIRE_VERSION:=simonrose
 
 # The definitions shown below can also be placed in an untracked RELEASE.local
--include $(TOP)/../../RELEASE.local
--include $(TOP)/../RELEASE.local
+#-include $(TOP)/../../RELEASE.local
+#-include $(TOP)/../RELEASE.local
 -include $(TOP)/configure/RELEASE.local
 

--- a/configure/RELEASE_DEV
+++ b/configure/RELEASE_DEV
@@ -2,7 +2,7 @@
 EPICS_BASE=/epics/base-7.0.3.1
 
 E3_REQUIRE_NAME:=require
-E3_REQUIRE_VERSION:=3.1.2
+E3_REQUIRE_VERSION:=3.2.0
 
 # The definitions shown below can also be placed in an untracked RELEASE_DEV.local
 -include $(TOP)/../../RELEASE_DEV.local


### PR DESCRIPTION
Updates the asyn.Makefile to use the DBDCAT-type rules that are included in require 3.2.0.